### PR TITLE
Rebuild theme details page to load changelog live from GitHub Releases

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1190 +1,236 @@
-<html lang="en-US"><head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
 <meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="profile" href="http://gmpg.org/xfn/11">
-<link rel="pingback" href="https://disciple.tools/xmlrpc.php">
-<title>Disciple.Tools</title>
-<link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="dns-prefetch" href="//s.w.org">
-<link rel="alternate" type="application/rss+xml" title="Disciple.Tools » Feed" href="https://disciple.tools/feed/">
-<link rel="alternate" type="application/rss+xml" title="Disciple.Tools » Comments Feed" href="https://disciple.tools/comments/feed/">
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/disciple.tools\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.9.1"}};
-			!function(a,b,c){function d(a,b){var c=String.fromCharCode;l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,a),0,0);var d=k.toDataURL();l.clearRect(0,0,k.width,k.height),l.fillText(c.apply(this,b),0,0);var e=k.toDataURL();return d===e}function e(a){var b;if(!l||!l.fillText)return!1;switch(l.textBaseline="top",l.font="600 32px Arial",a){case"flag":return!(b=d([55356,56826,55356,56819],[55356,56826,8203,55356,56819]))&&(b=d([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]),!b);case"emoji":return b=d([55358,56794,8205,9794,65039],[55358,56794,8203,9794,65039]),!b}return!1}function f(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var g,h,i,j,k=b.createElement("canvas"),l=k.getContext&&k.getContext("2d");for(j=Array("flag","emoji"),c.supports={everything:!0,everythingExceptFlag:!0},i=0;i<j.length;i++)c.supports[j[i]]=e(j[i]),c.supports.everything=c.supports.everything&&c.supports[j[i]],"flag"!==j[i]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[j[i]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(h=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",h,!1),a.addEventListener("load",h,!1)):(a.attachEvent("onload",h),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),g=c.source||{},g.concatemoji?f(g.concatemoji):g.wpemoji&&g.twemoji&&(f(g.twemoji),f(g.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script><script src="https://disciple.tools/wp-includes/js/wp-emoji-release.min.js?ver=4.9.1" type="text/javascript" defer=""></script>
-		<style type="text/css">
-img.wp-smiley,
-img.emoji {
-	display: inline !important;
-	border: none !important;
-	box-shadow: none !important;
-	height: 1em !important;
-	width: 1em !important;
-	margin: 0 .07em !important;
-	vertical-align: -0.1em !important;
-	background: none !important;
-	padding: 0 !important;
-}
-</style>
-<link rel="stylesheet" id="launch-understrap-styles-css" href="https://disciple.tools/wp-content/themes/launch/css/theme.min.css?ver=0.4.4" type="text/css" media="all">
-<link rel="stylesheet" id="launch-google-fonts-css" href="https://fonts.googleapis.com/css?family=Roboto%3A100%2C100i%2C300%2C300i%2C400%2C400i%2C500%2C500i%2C700%2C700i&amp;ver=4.9.1" type="text/css" media="all">
-<link rel="stylesheet" id="launch-styles-css" href="https://disciple.tools/wp-content/themes/launch/style.css?ver=0.4.4" type="text/css" media="all">
-<link rel="stylesheet" id="launch-multicolumnsrow-css-css" href="https://disciple.tools/wp-content/themes/launch/css/multi-columns-row.css?ver=4.9.1" type="text/css" media="all">
-<script type="text/javascript" src="https://disciple.tools/wp-includes/js/jquery/jquery.js?ver=1.12.4"></script>
-<script type="text/javascript" src="https://disciple.tools/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1"></script>
-<link rel="https://api.w.org/" href="https://disciple.tools/wp-json/">
-<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://disciple.tools/xmlrpc.php?rsd">
-<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://disciple.tools/wp-includes/wlwmanifest.xml"> 
-<meta name="generator" content="WordPress 4.9.1">
-<link rel="canonical" href="https://disciple.tools/">
-<link rel="shortlink" href="https://disciple.tools/">
-<link rel="alternate" type="application/json+oembed" href="https://disciple.tools/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdisciple.tools%2F">
-<link rel="alternate" type="text/xml+oembed" href="https://disciple.tools/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdisciple.tools%2F&amp;format=xml">
-    <style type="text/css">
-        a:hover, a:focus {color:#3f729b;}
-        .widget-area aside .widget-title {border-left-color: #3f729b;}
-        #wrapper-footer, #wrapper-footer-full, .header, .header-featured, #wrapper-footer .widget_mc4wp_form_widget .input-group-addon, .header-featured .jumbotron {background-color: #3f729b}
-        .btn-primary.focus, .btn-primary:focus, .btn-primary:hover, .btn-primary, .post .cat-links a {background-color: #b2ff59;}
-        .btn-primary.focus, .btn-primary:focus, .btn-primary:hover, .btn-primary {border-color: #b2ff59;}
-    </style>
-    		<style type="text/css" id="wp-custom-css">
-			/*
-You can add your own CSS here.
+<title>Disciple.Tools Theme — Release Notes</title>
+<!--
+  This page is the `details_url` target for the Disciple.Tools theme updater
+  (see disciple-tools-theme-version-control.json). WordPress opens it inside a
+  thickbox iframe when an admin clicks "View version x.y.z details" on the
+  Themes screen, so it must remain embeddable (GitHub Pages sends no
+  X-Frame-Options header; github.com itself denies framing, which is why the
+  link cannot point straight at the GitHub releases page).
 
-Click the help icon above to learn more.
-*/
-
-.entry-title {
-	display:none
-}
-.btn-primary {
-	color: black
-}
-.header {
-	padding-bottom:10px;
-}
-.header-featured {
-	padding-top:0;
-}
-.jumbotron {
-	padding-top: 2px;
-}
-blockquote {
-  margin: 0 0 10px 10px;
-  padding: 10px 20px;
-  border-left: 5px solid #3F729B;
-  font-size: 18px;
-  line-height: 22px;
-	font-family:Arial, serif;
-}
-blockquote p {
-	display:inline;
-}
-blockquote:before {
-  color: #ccc;
-  content: "\201C";
-  font-size: 4em;
-  line-height: 0.1em;
-  margin-right: 0.25em;
-  vertical-align: -0.4em;
-}
-#wrapper-footer-full {
-	display:none;
-}
-.featured-image {
-	margin-top: -230px !important; 
-	top: 230px;
-	position:relative;
-}
-#page-wrapper {
-	margin-top: 5%
-}
-@media only screen and (max-width: 400px) {
-    #page-wrapper {
-        margin-top: 34%;
-    }
-}
-.center-block {
-	margin-top: 40px;
-}
-.lead {
-	max-width: 780px;
-    margin-right: auto;
-    margin-left: auto;
-}
-.entry-content li {
-    margin-bottom: 0.5rem;
-}		</style>
-	</head>
-<body class="home page-template-default page page-id-12 wp-custom-logo">
-<div id="page" class="hfeed site">
-    <div class="wrapper header">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-offset-4 col-md-4 vcenter">
-                   <a href="https://disciple.tools/" class="custom-logo-link" rel="home" itemprop="url"><img src="https://disciple.tools/wp-content/uploads/2020/04/dt-emblem-150px.png" class="custom-logo" alt="Disciple.Tools" itemprop="logo"></a>                                        
-                </div>
-                <div class="col-md-8 pull-right">
-                    <a class="skip-link screen-reader-text sr-only" href="#content">Skip to content</a>
-                    <nav class="navbar navbar-dark site-navigation" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
-                        <div class="navbar-header"></div>
-                    </nav><!-- .site-navigation -->
-                </div>
-            </div>
-        </div>
-    </div>
-<div id="header-featured" class="wrapper">
-    <div class="container">
-
-        <p>In less than 20 minutes, you could be equipped to effectively engage and serve God-seekers as they discover, share and obey Him.</p>
-        <hr>
-        <p>&nbsp;</p>
-        <h2 style="text-align: left;">&nbsp;<strong>Testimonial</strong></h2>
-            <blockquote>
-                <p>The concepts behind Disciple.Tools help us identify which disciples are maturing and which disciples are multiplying and forming groups. We are excited that those concepts will soon be available within a tool kit that anyone can use anywhere.
-                </p>
-            </blockquote>	
-        <p>&nbsp;</p>
-        <hr>
-        <p>&nbsp;</p>
-        <h1 style="text-align: center;">What is Disciple.Tools?</h1>
-        <p style="text-align: center;"><strong>Disciple.Tools is a customized WordPress installer that will have the following components:</strong></p>
-        <div style="display: flex; flex-wrap: wrap;">
-            <ul style="flex: 1 0 320px; margin-bottom: 0;">
-            <li>contacts tracking and follow-up management</li>
-            <li>baptism and multiplication generations</li>
-            <li>mobile first web design</li>
-            <li>user management and communication for coordinating a coalition</li>
-            <li>reporting integration to Facebook, Google Analytics, Mailchimp, Twitter, and more</li>
-            </ul>
-            <ul style="flex: 1 0 320px;">
-            <li>prayer network tracking, reporting, and prayer guide publishing</li>
-            <li>partner network communication and updates publishing</li>
-            <li>dashboards, charts, and maps to show health and progress of the outreach</li>
-            <li>extendability through the 40k plugins on the WordPress</li>
-            <li>marketplace open source, preconfigured, low-tech skills required, cheap hosting options</li>
-            </ul>
-        </div>            
-
-    </div><!-- end of container -->
-</div><!-- end of header-featured -->
-<div class="wrapper" id="page-wrapper"> 
-    <div id="content" class="container">
-        <div class="row">
-    	   <div id="primary" class="col-md-12 content-area">         
-                 <main id="main" class="site-main" role="main">                        
-
-                  <article id="post-12" class="post-12 page type-page status-publish hentry">
-<!--                     <header class="entry-header">
-                      <h2 class="entry-title">Home</h2>
-                    </header><!-- .entry-header -->   
-<!-- -->
-                    <div class="entry-content">		
-
-                    <h1 style="margin-left: 10%;">Release Notes</h1>
-
+  The changelog is fetched client-side from the GitHub Releases API, which is
+  the source of truth for release notes — this page never needs a manual
+  update when a new version ships.
+-->
 <style>
-  .release-block {
-      width: 100%;
-      border-top: 1px solid #cccccc;
-      padding-top: .2em;
-      margin-bottom: .4em;
+  :root {
+    --dt-blue: #3f729b;
+    --text: #2c3338;
+    --muted: #646970;
+    --border: #dcdcde;
+    --bg: #ffffff;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text);
+    background: var(--bg);
+  }
+  .page-header {
+    background: var(--dt-blue);
+    color: #fff;
+    padding: 18px 28px;
+  }
+  .page-header h1 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+  }
+  .page-header p {
+    margin: 4px 0 0;
+    font-size: 13px;
+    opacity: 0.85;
+  }
+  .page-header a { color: #fff; }
+  main {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 20px 28px 40px;
+  }
+  .status {
+    padding: 24px 0;
+    color: var(--muted);
+  }
+  .status a { color: var(--dt-blue); }
+  .release {
+    border-bottom: 1px solid var(--border);
+    padding: 22px 0;
+  }
+  .release:last-child { border-bottom: none; }
+  .release-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .release-header h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--dt-blue);
+  }
+  .release-header h2 a { color: inherit; text-decoration: none; }
+  .release-header h2 a:hover { text-decoration: underline; }
+  .release-date {
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .latest-badge {
+    background: var(--dt-blue);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 2px 8px;
+    border-radius: 10px;
+  }
+  .release-body { margin-top: 8px; }
+  .release-body.empty { color: var(--muted); font-style: italic; }
+  .release-body.empty a { color: var(--dt-blue); font-style: normal; }
+  /* Release notes come from GitHub-rendered markdown; keep its headings
+     subordinate to the per-release version heading. */
+  .release-body h1, .release-body h2 { font-size: 16px; margin: 18px 0 6px; }
+  .release-body h3 { font-size: 15px; margin: 16px 0 6px; }
+  .release-body h4, .release-body h5, .release-body h6 { font-size: 14px; margin: 14px 0 4px; }
+  .release-body ul, .release-body ol { padding-left: 24px; margin: 6px 0; }
+  .release-body li { margin: 2px 0; }
+  .release-body a { color: var(--dt-blue); }
+  .release-body img { max-width: 100%; height: auto; }
+  .release-body pre {
+    background: #f6f7f7;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 10px 12px;
+    overflow-x: auto;
+  }
+  .release-body code {
+    background: #f6f7f7;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+  .release-body pre code { background: none; padding: 0; }
+  .page-footer {
+    margin-top: 28px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 13px;
+  }
+  .page-footer a { color: var(--dt-blue); }
+</style>
+</head>
+<body>
+<header class="page-header">
+  <h1>Disciple.Tools Theme — Release Notes</h1>
+  <p>Changelog for the <a href="https://github.com/DiscipleTools/disciple-tools-theme" target="_blank" rel="noopener">Disciple.Tools theme</a>, loaded live from GitHub Releases.</p>
+</header>
+<main>
+  <div id="content" class="status">Loading release notes&hellip;</div>
+  <div class="page-footer">
+    Full release history: <a href="https://github.com/DiscipleTools/disciple-tools-theme/releases" target="_blank" rel="noopener">github.com/DiscipleTools/disciple-tools-theme/releases</a>
+  </div>
+</main>
+<script>
+(function () {
+  var REPO = 'DiscipleTools/disciple-tools-theme';
+  var RELEASES_URL = 'https://github.com/' + REPO + '/releases';
+  var content = document.getElementById('content');
+
+  function showError() {
+    content.className = 'status';
+    content.innerHTML =
+      'Release notes could not be loaded right now. ' +
+      'View them directly on <a href="' + RELEASES_URL + '" target="_blank" rel="noopener">GitHub</a>.';
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text) node.textContent = text;
+    return node;
+  }
+
+  // This page is shown inside the WP admin thickbox iframe, and github.com
+  // refuses to render in frames — so every link must escape the iframe.
+  function retargetLinks(root) {
+    var links = root.querySelectorAll('a');
+    for (var i = 0; i < links.length; i++) {
+      links[i].setAttribute('target', '_blank');
+      links[i].setAttribute('rel', 'noopener');
+    }
+  }
+
+  function render(releases) {
+    releases = releases.filter(function (r) { return !r.draft && !r.prerelease; });
+    if (!releases.length) { showError(); return; }
+
+    content.className = '';
+    content.innerHTML = '';
+
+    releases.forEach(function (release, index) {
+      var section = el('section', 'release');
+      var header = el('div', 'release-header');
+
+      var heading = el('h2');
+      var link = el('a', null, release.tag_name);
+      link.href = release.html_url;
+      heading.appendChild(link);
+      header.appendChild(heading);
+
+      if (index === 0) header.appendChild(el('span', 'latest-badge', 'Latest'));
+
+      if (release.published_at) {
+        var date = new Date(release.published_at);
+        header.appendChild(el('span', 'release-date', date.toLocaleDateString(undefined, {
+          year: 'numeric', month: 'long', day: 'numeric'
+        })));
       }
-  .version-number {
-      width:25%;
-      float:left;
+      section.appendChild(header);
+
+      var body = el('div', 'release-body');
+      if (release.body_html && release.body_html.trim()) {
+        // body_html is GitHub's own sanitized rendering of the release notes.
+        body.innerHTML = release.body_html;
+      } else {
+        // Patch releases ship without written notes.
+        body.className += ' empty';
+        body.appendChild(document.createTextNode('Maintenance release — bug fixes and minor improvements.'));
+        var previous = releases[index + 1];
+        if (previous) {
+          body.appendChild(document.createTextNode(' '));
+          var compare = el('a', null, 'View the commits');
+          compare.href = 'https://github.com/' + REPO + '/compare/' +
+            encodeURIComponent(previous.tag_name) + '...' + encodeURIComponent(release.tag_name);
+          body.appendChild(compare);
+          body.appendChild(document.createTextNode('.'));
+        }
       }
-  .changed-items {
-      width: 74%;
-      float:right;
-      }
-  </style>
+      section.appendChild(body);
+      content.appendChild(section);
+    });
 
-<div style="display: flex; flex-wrap: wrap; max-width: 80%; margin: 20px auto;">
-	
-<!-- ****************************************************************************************************** -->		
+    retargetLinks(content);
+  }
 
-<!-- RELEASE NOTES GO HERE -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.8.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>New:</li>
-				<li>Front porch: Initial code for setting up a "home" webpage</li>
-				<li>Custom Fields: Connection. Create your own connection fields</li>
-				<li>Upgrade:</li>
-				<li>Mapping: Test Geo-location Key when adding it</li>
-				<li>Better login workflow to remember target url</li>
-				<li>Merging: All fields should now merge correctly</li>
-				<li>Fix bug keeping the Digital Responder from seeing all contacts</li>
-				<li>Top Nav Bar: collapse extra tabs into a dropdown</li>
-				<li>More Bug fixes</li>
-
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.7.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>New Features:</li>
-				<li>Ability to filter for "any" connection of a connection field. Ex searching for all contacts that have a coach. by @squigglybob</li>
-				<li>Ability to favorite contacts and groups. by @micahmills</li>
-				<li>Ability to change multi_select field icons (like Faith Milestones). By @cwuensche</li>
-				<li>Upgrades to dropdown field with a default "empty" value and the ability to filter for "no" value</li>
-				<li>Dev:</li>
-				<li>Upgrade magic url classes and add example to starter plugin</li>
-				<li>Ability to add user apps (features that a user can enable).</li>
-
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.6.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>New Features:</li>
-				<li>Advanced Global Search in the top navbar by @kodinkat</li>
-				<li>Tags field type, create your own tag field form the WP Admin by @cairocoder01</li>
-				<li>Personal/Private Fields, create private fields in the WP Admin to track personal data by @micahmills</li>
-				<li>Metrics: Fields over Time Charts, chose a field and see it's progression over time by @squigglybob</li>
-				<li>Fixes:</li>
-				<li>Fix locations not showing up in list view by @corsacca</li>
-				<li>Some date's not showing in user's selected language by @squigglybob</li>
-				<li>Fix some user inviting and upgrading workflows by @corsacca</li>
-				<li>Better contact transfer on records with lots of comments by @corsacca</li>
-				<li>WP Custom Fields section better UI by @prykon</li>
-				<li>WP ability to change field visibility on different contact types by @corsacca</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.5.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Upgrade Rest API Endpoints to WP standards by @cwuensche</li>
-				<li>Request Record Access 403 Page Button & Flow by @kodinkat</li>
-				<li>React to comments by @squigglybob</li>
-				<li>Click on tag to open filtered list page by @squigglybob ￼</li>
-				<li>Group members show status and baptism milestone icon by @squigglybob</li>
-				<li>Milestone icons by @squigglybob</li>
-				<li>Bug fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.4.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Create custom quick actions from the WP Admin by @prykon</li>
-				<li>Add Next and Previous list when viewing records from the list by @cwuensche</li>
-				<li>Save WP Errors to be viewed. Under WP Admin > Utilities (DT) > Error log by @kodinkat</li>
-				<li>Change Archived/Inactive Status to grey instead of red by @corsacca</li>
-				<li>Fields: Languages, Leader of Group and Subassigned on can be enabled. by @corsacca</li>
-				<li>More bug and UI fixes.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.3.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Add recently viewed filter to groups by @cwuensche</li>
-				<li>Ability to enable the "leader of group" field for the contact record by @corsacca</li>
-				<li>Show more location levels in the default locations typeahead by @corsacca @micahmills</li>
-				<li>Deactivate plugins from the WP Admin > Extensions (DT) Tab by @cwuensche</li>
-				<li>Show more info on who a record is shared with by @cwuensche</li>
-				<li>Create tags from the tags typeahead by @squigglybob</li>
-				<li>Ability to create custom Textarea fields by @micahmills</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.2.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Fixes for locations field with or without mapbox enabled by @corsacca</li>
-				<li>Mapbox/Geolocation documentation description: https://disciple.tools/user-docs/getting-started-info/admin/geolocation/</li>
-				<li>Upgrade contact to user modal improvements by @squigglybob</li>
-				<li>List page and new record page UI tweeks by @squigglybob</li>
-				<li>New Notification dropdown and notification grouping by @squigglybob</li>
-				<li>Creating custom communications channel fix by @micahmills</li>
-				<li>Fix for Last Modified field being updated when a record was only viewed by @corsacca</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Let Disciple.Tools theme update with the Wordpress "Enable Automatic Updates" feature. See https://wordpress.org/support/article/plugins-themes-auto-updates/</li>
-				<li>Advanced search functionality. By @micahmills</li>
-				<li>Let records be opened in a new tab with CMD or CTL + click. By @micahmills</li>
-				<li>Auto Focus on more modals so you can start typing right away</li>
-				<li>Fix timezone bug for some notifications. By @micahmills</li>
-				<li>Fix some users not showing up in Typeahead fields</li>
-				<li>Restore missing people groups field to group details tile</li>
-				<li>Make phone numbers clickable again. By @micahmills</li>
-				<li>Add endpoint to provide server settings available before login.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>1.0.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>See list of changes here https://disciple.tools/news/disciple-tools-theme-version-1-0-changes-and-new-features/</li>
-			</ul>
-		</div>
-	</div>
- 	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.33.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Added Languages: Tagalog, Hindi, German, Bulgarian, Dutch, Vietnamese</li>
-				<li>Updated Languages: Turkish (update), Russian (update), Indonesian (update), Chinese (update), Korean</li>
-				<li>Bug Fixes</li>
-				<li>API endpoint to record to the activity log by @cairocoder01</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.33.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Added Languages: Nepali</li>
-				<li>Fix languages direction issue</li>
-				<li>Fix baptism date being in the wrong timezone @micahmills</li>
-				<li>New endpoint for contact transfers</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.32.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Celebrating new Languages:</li>
-				<li>- Bosnian</li>
-				<li>- Croatian</li>
-				<li>Development:</li>
-				<li>- Add check_permissions parameter to list_posts method (#1068) @cairocoder01 </li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.32.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Contact Duplicate Checker and Merging Upgrade</li>
-				<li>List Filter fixes</li>
-				<li>Allow typing Arabic or Persian numbers and dates into Date fields by @micahmills</li>
-				<li>Site link tweaks for IP filtering</li>
-				<li>Comments: show dates with time and hover</li>
-				<li>Group Tags @micahmills @mikeallbutt</li>
-				<li>Dev: add filter for assignable users</li>
-				<li>Fix update needed triggering early</li>
-				<li>Custom fields: dropdown UI has a default empty value.</li>
-				<li>Change the last_modified field to be a date type.</li>
-				<li>Languages: Slovenian and Serbian</li>
-				<li>Fixes</li>
-			</ul>
-		</div>
-	</div>
-		<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.31.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Comments: fix xss issue.</li>
-				<li>Core working languages list</li>
-				<li>User responsibility section on profile page.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.31.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Metrics section layout upgrade</li>
-				<li>Mapbox maps in metrics upgrade</li>
-				<li>Password reset on multisite fix</li>
-				<li>Users Map</li>
-				<li>User management upgrades</li>
-				<li>Fix contact seeker path activity</li>
-				<li>New Partner role and access by source for Digital Responder and Partner role.</li>
-				<li>Site Links: Improve site link error messages.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.29.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Mapbox location alternative upgrades</li>
-				<li>Update to user management UI</li>
-				<li>Option to add users from the front end</li>
-				<li>New Translations: Indonesian, Dutch, Chinese (simplified) and Chinese (traditional)</li>
-				<li>Translate comments with google translate feature by @micahmills</li>
-				<li>Better date formats @micahmills</li>
-				<li>Ability to clear dates @blachawk</li>
-				<li>Comment type creation @micahmills</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.28.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Lists: filter by connections and people groups</li>
-				<li>upgrade location grid with mapbox meta @ChrisChasm</li>
-				<li>User Management tools (found under the settings gear).</li>
-				<li>Upgrade custom post type list and details pages</li>
-				<li>translation and date formatting improvements by @micahmills</li>
-				<li>fix nav bar on medium screens @micahmills</li>
-				<li>notifications dates are shown as "2 days ago" format. @blachawk</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.27.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>New dynamic list filters system.</li>
-				<li>Fixes and improvements to typeaheads and API</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.27.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Portuguese Turkish and Persian translations.</li>
-				<li>More help text in modals by @mikeallbutt</li>
-				<li>Add quick contact create to relations, baptisms and coaching typeaheads.</li>
-				<li>Rest API: allow query by any connection for record lists</li>
-				<li>Translate people group names by @micahmills</li>
-				<li>Collapse and expand record tiles</li>
-				<li>add border radius to all modals by @wzcblair</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.26.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>more help modal documentation thanks to @mikeallbutt</li>
-				<li>green add record buttons thank to @mikeallbutt</li>
-				<li>upgrade to metrics mapping charts.</li>
-				<li>update D.T logos</li>
-				<li>get browsersync working again thanks to @blachawk</li>
-				<li>consistent tile titles by @mikeallbutt</li>
-				<li>translation fixes</li>
-				<li>fix redirect when the user is logged out of a page</li>
-				<li>contacts list last modified column by @blachawk</li>
-				<li>fix comments escaping issue by @blachawk</li>
-				<li>other fixes and bugs.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.25.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Critical Path: Only show active contacts in Movement Tracking
-				<li>Critical Path: Monthly custom metrics</li>
-				<li>Improvements to icons and help modals. Thanks to @mikeallbutt</li>
-				<li>Fix custom fields with non latin scripts</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.24.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Fix enqueue bug with child themes and metrics by @bradwellsb</li>
-				<li>Fix icon background in nav bar by @bradwellsb</li>
-				<li>Only show active site connects in contact transfer list</li>
-				<li>Comments and Activity by site links will show the link name on contacts and groups.</li>
-				<li>Sources are not hidden from the multiplier role any more.</li>
-				<li>Critical Path chart is now available to multipliers</li>
-				<li>API for comments: ability to set comment date and comment type</li>
-				<li>Location typeaheads: matched text in bold.</li>
-				<li>API endpoints to get and set user settings</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.23.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Contact transfer fix</li>
-				<li>Mapping and Goecoding improvements</li>
-				<li>Fix api connections in records list</li>
-				<li>Update Needed count on assign to list for dispatchers</li>
-				<li>Update needed icon on contacts and groups list</li>
-				<li>User availability section upgrade</li>
-				<li>Better tracking for user login</li>
-				<li>Ability to migrate any location.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.22.2</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>mapping mapbox feature</li>
-				<li>date picker fixes</li>
-				<li>migration tool for geonames.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.22.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Move from geonames to location_grid</li>
-				<li>Digital responder is limited to certain sources</li>
-				<li>many small fixes.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.22.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>dev: New post_user_meta table for user data pertaining to records</li>
-				<li>@mentions work on android</li>
-				<li>bug fixes</li>
-				<li>paginatable comments and activity.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.21.3</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>dev: phpunit tests</li>
-				<li>rest api fixes</li>
-				<li>updraftplus backups only works with D.T with the payed version.</li>
-				<li>fix: status when creating new contacts</li>
-				<li>fix: waiting to be accepted count on list page</li>
-				<li>fix: notification for assignment and update needed sometimes not sending</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.21.1 and 0.21.2</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Bug fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.21.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>New locations system: see https://disciple-tools.readthedocs.io/en/latest/Disciple_Tools_Theme/getting_started/admin.html#how-to-migrate-old-locations</li>
-				<li>Custom Post Types: see https://github.com/DiscipleTools/disciple-tools-theme/wiki/Custom-post-types</li>
-				<li>User register email notification fixes.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.20.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Make sure user invitation emails are being sent out and that a user is correctly linked with their contact.
-				<li>Grey out closed contacts in contact typeahead lists.</li>
-				<li>Bug fixes</li>
-				<li>Translation updates</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.19.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Some security fixes and upgrades</li>
-				<li>Some speed upgrades</li>
-				<li>Tool to list fields and keys</li>
-				<li>Remove google charts dependency</li>
-				<li>Show follow button on mobile</li>
-				<li>Fix notifications loading</li>
-				<li>Plugin loading improvements and fixes</li>		
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.19.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>dd functions required by plugins to global function file.</li>
-				<li>Bug Fixes</li>			
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.18.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Metrics upgrades: sources, workers, critical path</li>
-				<li>Duplicate finder fixes</li>
-				<li>Bengali translation</li>
-				<li>Rest API access fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.16.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Upgrade and simplify translations</li>
-				<li>French translation</li>
-				<li>List Filters UI and functionality upgrade</li>
-				<li>Contact and Group record UI upgrade</li>
-				<li>Group members list</li>
-				<li>Metrics Group, Baptism, Location and Coaching Trees</li>
-				<li>Metrics Workers Activity and page</li>
-				<li>Metrics Prayer List</li>
-				<li>User icon in typeaheads</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.14.2</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>fix sources filter</li>
-				<li>add date filter</li>
-				<li>fix admin bug</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.14.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Show hidden site transfer in share modal</li>
-				<li>Customization fixes</li>
-				<li>Upload Spanish and Taiwanese translations</li> 
-				<li>Fix some translation issues</li>
-				<li>Fix deleting a contact connection and correct activity message</li>
-				<li>Set your own social media channel icons. Fix social media urls being hidden</li>
-				<li>Customizable church type</li>
-				<li>Comment and activity tab upgrades</li>
-				<li>General fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.14.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-			    <li>Customization system: add new tiles and fields to the contacts and group record pages</li>
-			    <li>Site to Site contact transfer</li>
-			    <li>Upgraded contact 'Overall Status' default fields</li>
-			    <li>Added Contact connections/relationships field</li>
-			</ul>
-			Developer:
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-			    <li>better api connection strategy and documentation.</li>
-			    <li>changed miltesones and health metrics to be multi_select fields instead of a bunch of individual fields</li>
-			    <li>create new boolean field. affects requires_update, accepted</li>
-			    <li>migrated a reason_paused key from 'not-responding' to 'not_responding'</li>
-			    <li>refactor add_comment function for contacts and groups</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.13.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<ul>Better Metrics charts and role access.</li>
-				<ul>Better site to site connection with permissions</li>
-				<ul>church start date</li>
-				<ul>church planter field</li>
-				<ul>Baptism workflow modal</li>
-				<ul>Searching contacts in typeaheads improved.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.12.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<ul>Merge a contact with another contact</li>
-				<ul>Duplicates modal with list of potential duplicates</li>
-				<ul>Better Activity/Comment section</li>
-				<ul>Fix deleting phone numbers and editing contact name.</li>
-				<ul>Network tab, site to site or partner link</li>
-				<ul>Link a contact to a user.</li>
-				<ul>Display name in user table</li>
-
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.11.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Updated needed fixes</li>
-				<li>Filter for sources</li>
-				<li>Metrics improvements</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.10.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>notification upgrades and fixes</li>
-				<li>filters bugs</li>
-				<li>more custom field options</li>
-				<li>tags on the contact record</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.9.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>More filters for Contacts List.</li>
-				<li>csv contacts import</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.9.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Customize options for current fields like: seeker path, milestones, group health metrics</li>
-				<li>Suggested plugins section on extensions page</li>
-				<li>Update needed trigger in settings</li>
-				<li>Critical path in metrics</li>
-				<li>Bug fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.8.2</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Notification fixes</li>
-				<li>links in comments are clickable</li>
-				<li>alphabetic ordering of lists</li>
-				<li>plugin portal</li>
-				<li>edit and delete comments</li>
-				<li>edit list filters</li>
-				<li>dev: wp can now be installed in a subfolder</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.8.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>A lot of work in preparing the metrics tab to be modular</li>
-				<li>Some personal and project metrics</li>
-				<li>Better searching in lists and typeahead fixed</li>
-				<li>Notification improvements</li>
-				<li>Follow button</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.8.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Awesome location geocoding and auto location generating</li>
-				<li>Complete revamp of the Contact and Group lists</li>
-				<li>Make and save filters and the list pages</li>
-				<li>Edit Contact and Group details in their own modal</li>
-				<li>Settings page improvements</li>
-				<li>@mention fix for notifications</li>
-				<li>add gravatar next to user names</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.7.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Subject line in emails is now configurable</li>
-				<li>Login won't always take you to the contacts page</li>
-				<li>Better mobile view on lists page</li>
-				<li>Redirect to requested page after login.</li>
-				<li>duplicate checking on contacts</li>
-				<li>location dropdown on contact creation changed to typeahead</li>
-				<li>Site to site connection upgrades.</li>
-				<li>leaders on groups</li>
-				<li>hooks for contact and group creation and update</li>
-				<li>api set locations by name</li>
-				<li>api use email to connect to a user's contact</li>
-				<li>more fixes</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.7.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>French Translation</li>
-				<li>contact source can now have multiple values</li>
-				<li>site to site linking between DT instances</li>
-				<li>contact details fixes</li>
-				<li>faster contact and group lists with caching</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.6.2</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Help icons on contact and group details</li>
-				<li>Contact details: status color</li>
-				<li>Better @mentions visual feedback</li>
-				<li>Safari UI fixes</li>
-				<li>Better warnings if you are not on php 7</li>
-                                <li>Contact and Group GRUD documented here: https://github.com/DiscipleTools/disciple-tools-theme/wiki</li>
-				<li>Ability to add custom fields and sections to groups and contacts.</li>
-				<li>See selected tab in navbar</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.6.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Migration error handling</li>
-				<li>user taxonomy group error fix</li>
-				<li>new install roles adjustment</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->	
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.6.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>improve update needed and assigned boxes on contact</li>
-				<li>add icons to contact details fields</li>
-				<li>improve nav bar</li>
-				<li>improve filters and contacts</li>
-				<li>fixes for activity and notifications</li>			
-				<li>style upgrades</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.5.1</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Fix bug when getting contact activity</li> 
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.5.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Add notification icon and fix navbar being big when loading</li> 
-				<li>Quick action button workflow, revert capability</li>
-				<li>Improve sharing contact UI, notifications and automation</li>
-				<li>Split group status and group type for clarity</li>
-				<li>403 page for limited permissions</li>
-				<li>child groups and parent groups</li>
-				<li>See https://github.com/DiscipleTools/disciple-tools-theme/milestone/4</li>
-				<li>and https://github.com/DiscipleTools/disciple-tools-theme/milestone/5</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.2.0</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Translation</li>
-				<li>@mentions in comments</li>
-				<li>@Import locations</li>
-				<li>See https://github.com/DiscipleTools/disciple-tools-theme/milestone/1</li>
-				<li>and https://github.com/DiscipleTools/disciple-tools-theme/milestone/3</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.1.4</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Testing theme update system</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.1.3</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Major system change! </li>
-				<li>IMPORTANT NOTE: YOU MUST DEACTIVATE 'Disciple.Tools PLUGIN' BEFORE UPDATING THIS THEME, OR THERE WILL BE CONFLICTS WITH THE PLUGIN FUNCTIONS.</li>
-				<li>Major clean up of admin enviornment.</li>
-				<li>Initial language translations.</li>
-				<li>Removal of integrations in preparation of adding them to independent plugins.</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-	
-	<!-- New Release Block -->
-	<div class="release-block">
-		<div class="version-number">
-			<p><strong>v0.1.0 (MVP)</strong></p>
-		</div>
-		<div class="changed-items">
-			<ul style="flex: 1 0 320px; margin-bottom: 0;">
-				<li>Private release. Minimum Viable Product (MVP) release</li>
-				<li>Basic contact management</li>
-				<li>Basic group tracking</li>
-				<li>Notifications</li>
-				<li>Metrics</li>
-				<li>User Management</li>
-			</ul>
-		</div>
-	</div>
-	<!-- End New Release Block -->
-			
-<!-- END RELEASE NOTES -->	
-<!-- ****************************************************************************************************** -->		
-<!-- ****************************************************************************************************** -->			
-<!-- ****************************************************************************************************** -->		
-	
-</div>
-	</div><!-- .entry-content -->
-	<footer class="entry-footer">	
-	</footer><!-- .entry-footer -->
-</article><!-- #post-## -->                  
-                </main><!-- #main -->            
-    	    </div><!-- #primary -->         
-        </div><!-- .row -->        
-    </div><!-- Container end -->    
-</div><!-- Wrapper end -->
-<div class="wrapper" id="wrapper-footer-full">  
-    <div class="container">
-        <div class="row">
-            <div class="col-md-6">   
-                <footer id="colophon" class="site-footer" role="contentinfo">
-                    <div class="site-info">Disciple.Tools</div><!-- .site-info -->
-                </footer><!-- #colophon -->      
-            </div><!--col end -->
-            <div class="col-md-6">
-                    <ul class="social-icons pull-right">
-                        <li><a class="icon fa fa-rss" href="https://disciple.tools/?feed=rss2" data-original-title="RSS"></a></li>
-                    </ul>                
-            </div>
-        </div><!-- row end -->      
-    </div><!-- container end -->   
-</div>
-</div><!-- #page -->
-<a class="github-ribbon" href="https://github.com/DiscipleTools/disciple-tools-theme" target="_blank"><img style="position: fixed; top: 0; right: 0; border: 0;z-index:100000" src="//s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a><script type="text/javascript" src="https://disciple.tools/wp-content/themes/launch/js/theme.min.js?ver=0.4.4"></script>
-<script type="text/javascript" src="https://disciple.tools/wp-includes/js/wp-embed.min.js?ver=4.9.1"></script>
-</body></html>
+  fetch('https://api.github.com/repos/' + REPO + '/releases?per_page=100', {
+    headers: { 'Accept': 'application/vnd.github.html+json' }
+  })
+    .then(function (response) {
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      return response.json();
+    })
+    .then(render)
+    .catch(showError);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes DiscipleTools/disciple-tools-theme#2922 — the "View version x.y.z details" link in WP Admin → Themes lands on a changelog that ends at 1.8.0.

## Problem

The theme updater's `details_url` (from `disciple-tools-theme-version-control.json`) points to this repo's GitHub Pages site, which was a static 2017 snapshot of the disciple.tools homepage with a hand-maintained changelog that stopped at 1.8.0.

## Why not point `details_url` at the GitHub releases page?

WordPress opens `details_url` inside a thickbox **iframe** (it appends `TB_iframe=true` — see `get_theme_update_available()` in `wp-admin/includes/theme.php`), and github.com sends `X-Frame-Options: deny`, so the modal would show "refused to connect" instead of release notes. GitHub Pages sends no frame restrictions, so this URL is the right place for the link to land — the page itself just needed fixing.

## Fix

Replaces `docs/index.html` with a self-contained page that fetches the changelog client-side from the GitHub Releases API (CORS-open, using the `application/vnd.github.html+json` media type so notes render exactly as GitHub renders them). GitHub releases are the source of truth for theme release notes, so the page **can never go stale again** — no manual updates needed when a version ships.

Details:

- Feature releases show their full published notes; patch releases (which ship with empty notes) show "Maintenance release" plus a tag-compare link to the commits
- All links are forced to `target="_blank"` so clicks escape the WP admin iframe (github.com links would otherwise be blocked inside it)
- If the API is unreachable or rate-limited, the page degrades to a direct link to the GitHub releases page
- `details_url` in the JSON is unchanged, so every installed theme version gets the fix as soon as this deploys to Pages

## Verification

Rendered in headless Chromium at 1024×800 (the exact thickbox size): 100 releases display, current through 1.82.1, full notes render for feature releases, and all links carry `target="_blank"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)